### PR TITLE
Fix issues

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -284,10 +284,10 @@ final class core_renderer extends \theme_boost\output\core_renderer {
     public function render_completion_footer(): string {
         global $COURSE;
 
-        if ($COURSE->enablecompletion != COMPLETION_ENABLED || $this->page->pagelayout == "admin") {
-            return '';
-        }
-        if ($this->page->bodyid == 'page-mod-quiz-attempt') {
+        if ($COURSE->enablecompletion != COMPLETION_ENABLED
+                || $this->page->pagelayout == "admin"
+                || $this->page->pagetype == "course-editsection"
+                || $this->page->bodyid == 'page-mod-quiz-attempt') {
             return '';
         }
 

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -34,9 +34,12 @@ use html_writer;
 use completion_info;
 use context_system;
 use moodle_url;
+use pix_icon;
+use action_menu_link_secondary;
+use action_menu;
+use action_menu_filler;
 
 defined('MOODLE_INTERNAL') || die;
-
 
 /**
  * Class core_renderer extended
@@ -287,7 +290,8 @@ final class core_renderer extends \theme_boost\output\core_renderer {
         if ($COURSE->enablecompletion != COMPLETION_ENABLED
                 || $this->page->pagelayout == "admin"
                 || $this->page->pagetype == "course-editsection"
-                || $this->page->bodyid == 'page-mod-quiz-attempt') {
+                || $this->page->bodyid == 'page-mod-quiz-attempt'
+                || (isset($this->page->cm->completion) && !$this->page->cm->completion)) {
             return '';
         }
 
@@ -488,5 +492,207 @@ final class core_renderer extends \theme_boost\output\core_renderer {
     public function carousel(): string {
         $carousel = $this->page->get_renderer('theme_telaformation', 'carousel');
         return $carousel->output();
+    }
+
+    /**
+     * Construct a user menu, returning HTML that can be echoed out by a
+     * layout file.
+     *
+     * @param stdClass $user A user object, usually $USER.
+     * @param bool $withlinks true if a dropdown should be built.
+     * @return string HTML fragment.
+     */
+    public function user_menu($user = null, $withlinks = null) {
+        global $USER, $CFG;
+        require_once($CFG->dirroot . '/user/lib.php');
+
+        if (is_null($user)) {
+            $user = $USER;
+        }
+
+        // Note: this behaviour is intended to match that of core_renderer::login_info,
+        // but should not be considered to be good practice; layout options are
+        // intended to be theme-specific. Please don't copy this snippet anywhere else.
+        if (is_null($withlinks)) {
+            $withlinks = empty($this->page->layout_options['nologinlinks']);
+        }
+
+        // Add a class for when $withlinks is false.
+        $usermenuclasses = 'usermenu';
+        if (!$withlinks) {
+            $usermenuclasses .= ' withoutlinks';
+        }
+
+        $returnstr = "";
+
+        // If during initial install, return the empty return string.
+        if (during_initial_install()) {
+            return $returnstr;
+        }
+
+        $loginpage = $this->is_login_page();
+        $loginurl = get_login_url();
+        // If not logged in, show the typical not-logged-in string.
+        if (!isloggedin()) {
+            if (!$loginpage) {
+
+                $returnstr = "<form action=\"$loginurl\">
+<button class='btn btn-primary' type='submit'>".
+                        get_string('login')."</button></form>";
+            } else {
+                $returnstr = get_string('loggedinnot', 'moodle');
+
+            }
+            return html_writer::div(
+                    html_writer::span(
+                            $returnstr,
+                            'login'
+                    ),
+                    $usermenuclasses
+            );
+
+        }
+
+        // If logged in as a guest user, show a string to that effect.
+        if (isguestuser()) {
+            $returnstr = get_string('loggedinasguest');
+            if (!$loginpage && $withlinks) {
+                $returnstr .= " (<a href=\"$loginurl\">".get_string('login').'</a>)';
+            }
+
+            return html_writer::div(
+                    html_writer::span(
+                            $returnstr,
+                            'login'
+                    ),
+                    $usermenuclasses
+            );
+        }
+
+        // Get some navigation opts.
+        $opts = user_get_user_navigation_info($user, $this->page);
+
+        $avatarclasses = "avatars";
+        $avatarcontents = html_writer::span($opts->metadata['useravatar'], 'avatar current');
+        $usertextcontents = $opts->metadata['userfullname'];
+
+        // Other user.
+        if (!empty($opts->metadata['asotheruser'])) {
+            $avatarcontents .= html_writer::span(
+                    $opts->metadata['realuseravatar'],
+                    'avatar realuser'
+            );
+            $usertextcontents = $opts->metadata['realuserfullname'];
+            $usertextcontents .= html_writer::tag(
+                    'span',
+                    get_string(
+                            'loggedinas',
+                            'moodle',
+                            html_writer::span(
+                                    $opts->metadata['userfullname'],
+                                    'value'
+                            )
+                    ),
+                    array('class' => 'meta viewingas')
+            );
+        }
+
+        // Role.
+        if (!empty($opts->metadata['asotherrole'])) {
+            $role = core_text::strtolower(preg_replace('#[ ]+#', '-', trim($opts->metadata['rolename'])));
+            $usertextcontents .= html_writer::span(
+                    $opts->metadata['rolename'],
+                    'meta role role-' . $role
+            );
+        }
+
+        // User login failures.
+        if (!empty($opts->metadata['userloginfail'])) {
+            $usertextcontents .= html_writer::span(
+                    $opts->metadata['userloginfail'],
+                    'meta loginfailures'
+            );
+        }
+
+        // MNet.
+        if (!empty($opts->metadata['asmnetuser'])) {
+            $mnet = strtolower(preg_replace('#[ ]+#', '-', trim($opts->metadata['mnetidprovidername'])));
+            $usertextcontents .= html_writer::span(
+                    $opts->metadata['mnetidprovidername'],
+                    'meta mnet mnet-' . $mnet
+            );
+        }
+
+        $returnstr .= html_writer::span(
+                html_writer::span($usertextcontents, 'usertext mr-1') .
+                html_writer::span($avatarcontents, $avatarclasses),
+                'userbutton'
+        );
+
+        // Create a divider (well, a filler).
+        $divider = new action_menu_filler();
+        $divider->primary = false;
+
+        $am = new action_menu();
+        $am->set_menu_trigger(
+                $returnstr
+        );
+        $am->set_action_label(get_string('usermenu'));
+        $am->set_alignment(action_menu::TR, action_menu::BR);
+        $am->set_nowrap_on_items();
+        if ($withlinks) {
+            $navitemcount = count($opts->navitems);
+            $idx = 0;
+            foreach ($opts->navitems as $key => $value) {
+
+                switch ($value->itemtype) {
+                    case 'divider':
+                        // If the nav item is a divider, add one and skip link processing.
+                        $am->add($divider);
+                        break;
+
+                    case 'invalid':
+                        // Silently skip invalid entries (should we post a notification?).
+                        break;
+
+                    case 'link':
+                        // Process this as a link item.
+                        $pix = null;
+                        if (isset($value->pix) && !empty($value->pix)) {
+                            $pix = new pix_icon($value->pix, '', null, array('class' => 'iconsmall'));
+                        } else if (isset($value->imgsrc) && !empty($value->imgsrc)) {
+                            $value->title = html_writer::img(
+                                            $value->imgsrc,
+                                            $value->title,
+                                            array('class' => 'iconsmall')
+                                    ) . $value->title;
+                        }
+
+                        $al = new action_menu_link_secondary(
+                                $value->url,
+                                $pix,
+                                $value->title,
+                                array('class' => 'icon')
+                        );
+                        if (!empty($value->titleidentifier)) {
+                            $al->attributes['data-title'] = $value->titleidentifier;
+                        }
+                        $am->add($al);
+                        break;
+                }
+
+                $idx++;
+
+                // Add dividers after the first item and before the last item.
+                if ($idx == 1 || $idx == $navitemcount - 1) {
+                    $am->add($divider);
+                }
+            }
+        }
+
+        return html_writer::div(
+                $this->render($am),
+                $usermenuclasses
+        );
     }
 }

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -24,14 +24,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-user_preference_allow_ajax_update(
-        'drawer-open-nav',
-        PARAM_ALPHA
-);
+user_preference_allow_ajax_update( 'drawer-open-nav', PARAM_ALPHA);
 require_once($CFG->libdir . '/behat/lib.php');
 
 if (isloggedin()) {
-    $navdraweropen = false;
+    $navdraweropen = (get_user_preferences('drawer-open-nav', 'true') == 'true');
 } else {
     $navdraweropen = false;
 }
@@ -42,7 +39,9 @@ if ($navdraweropen) {
 $bodyattributes = $OUTPUT->body_attributes($extraclasses);
 $blockshtml = $OUTPUT->blocks('side-pre');
 $hasblocks = strpos( $blockshtml, 'data-block=' ) !== false;
-$regionmainsettingsmenu = $OUTPUT->region_main_settings_menu();
+$buildregionmainsettings = !$PAGE->include_region_main_settings_in_header_actions();
+// If the settings menu will be included in the header then don't add it here.
+$regionmainsettingsmenu = $buildregionmainsettings ? $OUTPUT->region_main_settings_menu() : false;
 $hasfrontpageregions = $OUTPUT->get_block_regions();
 $iscarouselenabled = $OUTPUT->is_carousel_enabled();
 $templatecontext = [

--- a/scss/body.scss
+++ b/scss/body.scss
@@ -1,3 +1,26 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 body {
     font-family: unquote('googlefont'), serif;
 

--- a/scss/carousel.scss
+++ b/scss/carousel.scss
@@ -1,3 +1,31 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 .carousel {
-  width: 100%;
+    width: 100%;
+
+    .carousel-control-prev,
+    .carousel-control-next {
+        box-shadow: none;
+    }
 }

--- a/scss/catalog.scss
+++ b/scss/catalog.scss
@@ -1,3 +1,26 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 #page-course-index-category {
     .buttons {
         margin-top: 10px;
@@ -12,5 +35,22 @@
             max-height: 100%;
             max-width: 100%;
         }
+    }
+
+    .entercourse {
+        clear: both;
+        float: right;
+    }
+
+    .coursename a.aalink {
+        &:before {
+            content: '\f19d';
+            font: normal normal normal 14px/1 FontAwesome;
+        }
+    }
+
+    .coursebox > .info > .coursename a {
+        background: none;
+        padding-left: 21px;
     }
 }

--- a/scss/completioncheck.scss
+++ b/scss/completioncheck.scss
@@ -1,3 +1,26 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 .next_activity_area {
     background-color: transparent;
     margin-top: 0;

--- a/scss/coursecard.scss
+++ b/scss/coursecard.scss
@@ -1,3 +1,25 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 #frontpage-available-course-list {
     .dashboard-card-deck .dashboard-card {

--- a/scss/footer.scss
+++ b/scss/footer.scss
@@ -1,3 +1,25 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 footer {
     background-color: unquote('footercolor') !important;
@@ -12,4 +34,3 @@ footer {
         }
     }
 }
-

--- a/scss/frontpage.scss
+++ b/scss/frontpage.scss
@@ -1,3 +1,26 @@
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 .front-page-row {
 
     > div {

--- a/scss/navbar.scss
+++ b/scss/navbar.scss
@@ -52,6 +52,10 @@ nav.navbar.telaformation-navbar {
         color: #333 !important;
     }
 
+    .nav-item {
+        display: flex;
+    }
+
     .dropdown-toggle::after {
         display: none;
     }

--- a/scss/settings.scss
+++ b/scss/settings.scss
@@ -1,4 +1,26 @@
-// Banner settings page - display a description on top
+// This file is part of the Telaformation theme for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Telaformation style files.
+ * @package    theme_telaformation
+ * @copyright  Tela Botanica 2020
+ * @author     Sylvain Revenu - Pimenko 2020 <contact@pimenko.com> <pimenko.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 #page-admin-setting-themesettingtelaformation {
 
     #admin-settingsdescription,

--- a/templates/course_category_tree.mustache
+++ b/templates/course_category_tree.mustache
@@ -1,13 +1,21 @@
-<div class="course_category_tree m-b-20 clearfix">
-
-    {{#expandall}}
-        <div class="collapsible-actions">
-            <a href="#" class="courseopenall">{{ expandall }}</a>
-            <a href="#" class="coursecloseall hidden">{{ collapseall }}</a>
-        </div>
-    {{/expandall}}
-
-    <div class="content">
-        {{{ categorycontent }}}
+<div {{{contentattributes}}}>
+    <div class="collapsible-actions">
+        <a href="#" class="{{{linkclass}}}">{{{linkname}}}</a>
     </div>
+    <div class="content">{{{categorycontent}}}</div>
 </div>
+{{#js}}
+    <!--   We open all 1st rank category by default. -->
+    $(document).ready(function() {
+        if($('.categoryname')) {
+            $('.categoryname').click();
+        }
+
+        <!-- Change default event click action. -->
+        $('body').on('click', '.coursename a.aalink', function(event) {
+            event.preventDefault();
+            let selectormoreinfo = '#' + $(this).data('moreinfoid') + ' i';
+            $(selectormoreinfo).click();
+        });
+    });
+{{/js}}

--- a/templates/course_name.mustache
+++ b/templates/course_name.mustache
@@ -1,0 +1,6 @@
+<{{{nametag}}} class='coursename'>
+    {{{coursenamelink}}}
+</{{{nametag}}}>
+<div class="moreinfo">
+    <a id="{{{moreinfoid}}}" href="{{{url}}}" title="{{{title}}}">{{{image}}}</a>
+</div>

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -59,6 +59,7 @@
 
     {{> theme_boost/navbar }}
     {{> theme_boost/nav-drawer }}
+
     <div id="page" class="container-fluid">
         <div id="page-content" class="row">
             {{#iscarouselenabled}}
@@ -94,6 +95,7 @@
             </div>
         </div>
     </div>
+    {{{ output.standard_after_main_region_html }}}
     {{> theme_boost/footer }}
 </div>
 

--- a/templates/theme_boost/footer.mustache
+++ b/templates/theme_boost/footer.mustache
@@ -28,14 +28,8 @@
         <div id="course-footer">{{{ output.course_footer }}}</div>
         <!-- Custom footer content -->
         {{{ output.footer_custom_content }}}
-
-        {{# output.page_doc_link }}
-            <p class="helplink">{{{ output.page_doc_link }}}</p>
-        {{/ output.page_doc_link }}
-
         {{{ output.login_info }}}
         <div class="tool_usertours-resettourcontainer"></div>
-        {{{ output.home_link }}}
         <nav class="nav navbar-nav d-md-none" aria-label="{{#str}}custommenu, admin{{/str}}">
             {{# output.custom_menu_flat }}
                 <ul class="list-unstyled pt-3">


### PR DESCRIPTION
- Fix issue #31 
- Fix issue #28 
- Fix issue #26
1. make all the courses category accordions open by default
2. When you have the list of MOOCs to which you can register: put the summary before you can go to the home page of the course in question.
3. Change course logo in course/index.php by the scholar hat
4. Fix homepage carousel : when clicking on the sliders to slide, the focus is on blue > please delete the blue
remove the Moodle logo (and link) on footer
5. nav : when not connected, add a button with "connexion" instead of "Non connecté (connexion) (see : https://mooc.tela-botanica.org/ )

was done in local css : 
course cards display on home only : hide the card footer (percent completion)

was done by modifying the language package locally:
Change “cours disponibles” to “cours proposés”

Closes #31 
Closes #28
Closes #26

Will merge and deploy this tomorrow :)